### PR TITLE
Add accent color and Playfair Display

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="styles.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
 </head>
 <body>
   <!-- Hero -->

--- a/styles.css
+++ b/styles.css
@@ -3,6 +3,7 @@
   --green:#28b463;
   --charcoal:#1c1c1c;
   --grey:#f9fafb;
+  --accent:#e85d04;
 }
 body{
   margin:0;
@@ -16,9 +17,26 @@ body{
   margin:auto;
   text-align:center;
 }
-h1{font-size:2.4rem;margin:0 0 12px;line-height:1.2;}
-h2{font-size:1.8rem;margin:0 0 32px;}
-h3{margin:8px 0;font-size:1.1rem;}
+h1{
+  font-size:2.4rem;
+  margin:0 0 12px;
+  line-height:1.2;
+  font-family:'Playfair Display',serif;
+  font-weight:700;
+  color:var(--accent);
+}
+h2{
+  font-size:1.8rem;
+  margin:0 0 32px;
+  font-family:'Playfair Display',serif;
+  font-weight:700;
+  color:var(--accent);
+}
+h3{
+  margin:8px 0;
+  font-size:1.1rem;
+  font-family:'Playfair Display',serif;
+}
 .sub{max-width:640px;margin:0 auto 28px;color:#444;}
 .btn{
   display:inline-block;padding:12px 26px;border-radius:8px;


### PR DESCRIPTION
## Summary
- load Playfair Display along with additional Inter weights
- introduce `--accent` color
- apply Playfair Display and accent color to headings

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68691bb298508323815f51a58df144e9