### PR TITLE
Switch to remote theme

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source "https://rubygems.org"
-gem "jekyll-theme-chirpy"
 
 gem "jekyll", "~> 4.3"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,19 +78,12 @@ GEM
     jekyll-include-cache (0.2.1)
       jekyll (>= 3.7, < 5.0)
     jekyll-paginate (1.1.0)
-    jekyll-sass-converter (3.0.0)
-      sass-embedded (~> 1.54)
+    jekyll-sass-converter (3.1.0)
+      sass-embedded (~> 1.75)
     jekyll-seo-tag (2.8.0)
       jekyll (>= 3.8, < 5.0)
     jekyll-sitemap (1.4.0)
       jekyll (>= 3.7, < 5.0)
-    jekyll-theme-chirpy (7.3.0)
-      jekyll (~> 4.3)
-      jekyll-archives (~> 2.2)
-      jekyll-include-cache (~> 0.2)
-      jekyll-paginate (~> 1.1)
-      jekyll-seo-tag (~> 2.8)
-      jekyll-sitemap (~> 1.4)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     json (2.12.2)
@@ -177,7 +170,6 @@ DEPENDENCIES
   jekyll-paginate
   jekyll-seo-tag
   jekyll-sitemap
-  jekyll-theme-chirpy
 
 BUNDLED WITH
    2.6.7

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # ExcelFix24
 
 This site uses the Chirpy Jekyll theme.
+The theme is loaded via the `remote_theme` setting in `_config.yml`.

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: ExcelFix24
 url: "https://www.excelfix24.com"
 baseurl: ""
-theme: jekyll-theme-chirpy
+remote_theme: cotes2020/jekyll-theme-chirpy@v7.3.0
 


### PR DESCRIPTION
## Summary
- configure Chirpy as a remote theme in `_config.yml`
- remove `jekyll-theme-chirpy` gem and update dependencies
- note remote theme usage in the README

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68692ac62e208323be64cc4af92e475e