### PR TITLE
Add Jekyll build workflow

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -1,0 +1,27 @@
+name: Build and Deploy Jekyll site
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.1'
+        bundler-cache: true
+    - name: Install dependencies
+      run: bundle install --jobs 4 --retry 3
+    - name: Build site
+      run: bundle exec jekyll build
+    - name: Deploy to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./_site
+        publish_branch: gh-pages

--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@ The theme is loaded via the `remote_theme` setting in `_config.yml`.
 ## License
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
+
+## Deployment
+
+The site is built and deployed automatically using [GitHub Actions](.github/workflows/jekyll-gh-pages.yml). The generated content in `_site` is published to the `gh-pages` branch. Configure the repository's GitHub Pages settings to serve the site from this branch.


### PR DESCRIPTION
## Summary
- build the site on pushes using Jekyll 4
- deploy the `_site` directory to the `gh-pages` branch
- document how to enable GitHub Pages

## Testing
- `bundle install`
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68692f3bd9f083238f90749c879d7fac