### PR TITLE
Fix bundler install failure

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.1'
+        ruby-version: '3.2'
         bundler-cache: true
     - name: Install dependencies
       run: bundle install --jobs 4 --retry 3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,7 @@ PLATFORMS
   x86-linux-gnu
   x86-linux-musl
   x86_64-darwin
+  x86_64-linux
   x86_64-linux-android
   x86_64-linux-gnu
   x86_64-linux-musl


### PR DESCRIPTION
## Summary
- fix CI bundler by using Ruby 3.2
- update Gemfile.lock platforms

## Testing
- `bundle install --jobs 4 --retry 3`
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68693613d0908323ade0b113da9723f2