### PR TITLE
Add favicon, pages, and analytics

### DIFF
--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,0 +1,1 @@
+<script defer data-domain="excelfix24.com" src="https://plausible.io/js/plausible.js"></script>

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -6,10 +6,11 @@ title: "ExcelFix 24 – Rapid Spreadsheet Rescue"
 <link rel="stylesheet" href="{{ '/assets/css/custom.css' | relative_url }}">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
+<link rel="icon" href="{{ '/favicon.svg' | relative_url }}" type="image/svg+xml">
 
   <!-- Hero -->
   <header class="section hero">
+<img src="{{ '/assets/img/logo.svg' | relative_url }}" alt="ExcelFix24 logo" width="120">
     <h1>Fix dirty spreadsheets&nbsp;in&nbsp;24&nbsp;h.</h1>
     <p class="sub">Upload your file → pay → get a custom macro and Loom walkthrough tomorrow.</p>
     <a class="btn primary" href="https://docs.google.com/forms/d/e/1FAIpQLScXrZ8CXKn3zIAzqjyL3mc3_PKXks1M_hvgyaQtHF3L04s9sw/viewform?usp=header" target="_blank">Get your quote</a>
@@ -146,3 +147,4 @@ title: "ExcelFix 24 – Rapid Spreadsheet Rescue"
       updatePrices();
     })();
   </script>
+{% include analytics.html %}

--- a/_pages/privacy.md
+++ b/_pages/privacy.md
@@ -1,0 +1,8 @@
+---
+layout: page
+permalink: /privacy.html
+title: "Privacy Policy"
+---
+<link rel="icon" href="{{ '/favicon.svg' | relative_url }}" type="image/svg+xml">
+<p>We respect your privacy. Files are used only for delivering your fix and deleted after completion. Contact <a href="mailto:hello@excelfix24.com">hello@excelfix24.com</a> for questions.</p>
+{% include analytics.html %}

--- a/_pages/refund.md
+++ b/_pages/refund.md
@@ -1,0 +1,8 @@
+---
+layout: page
+permalink: /refund.html
+title: "Refund Policy"
+---
+<link rel="icon" href="{{ '/favicon.svg' | relative_url }}" type="image/svg+xml">
+<p>If we can't deliver your fix within 24 hours of payment, you'll receive a 100% refund.</p>
+{% include analytics.html %}

--- a/_pages/thanks.md
+++ b/_pages/thanks.md
@@ -1,0 +1,9 @@
+---
+layout: page
+permalink: /thanks.html
+title: "Thank you"
+---
+<link rel="icon" href="{{ '/favicon.svg' | relative_url }}" type="image/svg+xml">
+<p>Thanks for your purchase! We'll send your custom spreadsheet and Loom walkthrough soon.</p>
+<p><a href="{{ '/' | relative_url }}">Back to home</a></p>
+{% include analytics.html %}

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -78,3 +78,4 @@ h3{
 @media(max-width:600px){
   .three,.pricing .tiers{flex-direction:column;}
 }
+@media (prefers-color-scheme: dark){body{background:#121212;color:#eee;} .hero{color:#fff;background:linear-gradient(135deg,var(--green),#000);} .three .card,.tier,.testimonials blockquote{background:#1e1e1e;border-color:#333;color:#eee;} }

--- a/assets/img/logo.svg
+++ b/assets/img/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="30" viewBox="0 0 100 30">
+  <rect width="100" height="30" fill="#ffffff"/>
+  <text x="5" y="20" font-family="Arial, sans-serif" font-size="20" fill="#28b463">EF24</text>
+</svg>

--- a/email_templates/delivery_email_template.txt
+++ b/email_templates/delivery_email_template.txt
@@ -1,0 +1,8 @@
+Subject: Files for EF24-1234 – bug-fix until {{due_date}}
+
+Hi,
+
+Here are your updated files. You have a 7-day bug-fix window until {{due_date}}.
+
+Regards,
+ExcelFix24 Team

--- a/email_templates/quote_email_template.txt
+++ b/email_templates/quote_email_template.txt
@@ -1,0 +1,9 @@
+Subject: Your ExcelFix24 quote
+
+Hi there,
+
+Your ticket ID is {{ticket_id}}. The recommended tier is **{{tier}}**.
+To proceed, please pay via this link: {{payment_link}}
+
+Best regards,
+ExcelFix24 Team

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#28b463"/>
+  <text x="4" y="22" font-family="Arial, sans-serif" font-size="18" fill="#ffffff">EF</text>
+</svg>


### PR DESCRIPTION
## Summary
- add favicon and site logo
- create thanks, privacy, and refund pages
- add email templates for quotes and deliveries
- include Plausible analytics
- add dark mode styles

## Testing
- `bundle exec jekyll build` *(fails: jekyll not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68693b774d6c8323b2522273ae160ef8