### PR TITLE
Switch to Gradfolio theme

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,5 @@ group :jekyll_plugins do
   gem "jekyll-include-cache"
   gem "jekyll-seo-tag"
   gem "jekyll-paginate"
+  gem "jekyll-remote-theme"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,10 @@ GEM
     jekyll-include-cache (0.2.1)
       jekyll (>= 3.7, < 5.0)
     jekyll-paginate (1.1.0)
+    jekyll-remote-theme (0.4.1)
+      addressable (~> 2.0)
+      jekyll (>= 3.5, < 5.0)
+      rubyzip (>= 1.3.0)
     jekyll-sass-converter (3.1.0)
       sass-embedded (~> 1.75)
     jekyll-seo-tag (2.8.0)
@@ -105,6 +109,7 @@ GEM
       ffi (~> 1.0)
     rexml (3.4.1)
     rouge (4.5.2)
+    rubyzip (2.4.1)
     safe_yaml (1.0.5)
     sass-embedded (1.89.2)
       google-protobuf (~> 4.31)
@@ -169,6 +174,7 @@ DEPENDENCIES
   jekyll-archives
   jekyll-include-cache
   jekyll-paginate
+  jekyll-remote-theme
   jekyll-seo-tag
   jekyll-sitemap
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,9 @@
 title: ExcelFix24
 url: "https://www.excelfix24.com"
 baseurl: ""
-remote_theme: pages-themes/hacker@v0.2.0
+remote_theme: jitinnair1/gradfolio
+plugins:
+  - jekyll-remote-theme
 
 collections:
   pages:

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: default
 permalink: /
 title: "ExcelFix 24 – Rapid Spreadsheet Rescue"
 ---
@@ -10,7 +10,6 @@ title: "ExcelFix 24 – Rapid Spreadsheet Rescue"
 
   <!-- Hero -->
   <header class="section hero">
-<img src="{{ '/assets/img/logo.svg' | relative_url }}" alt="ExcelFix24 logo" width="120">
     <h1>Fix dirty spreadsheets&nbsp;in&nbsp;24&nbsp;h.</h1>
     <p class="sub">Upload your file → pay → get a custom macro and Loom walkthrough tomorrow.</p>
     <a class="btn primary" href="https://docs.google.com/forms/d/e/1FAIpQLScXrZ8CXKn3zIAzqjyL3mc3_PKXks1M_hvgyaQtHF3L04s9sw/viewform?usp=header" target="_blank">Get your quote</a>

--- a/_pages/privacy.md
+++ b/_pages/privacy.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: default
 permalink: /privacy.html
 title: "Privacy Policy"
 ---

--- a/_pages/refund.md
+++ b/_pages/refund.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: default
 permalink: /refund.html
 title: "Refund Policy"
 ---

--- a/_pages/thanks.md
+++ b/_pages/thanks.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: default
 permalink: /thanks.html
 title: "Thank you"
 ---

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -39,10 +39,11 @@ h3{
 }
 .sub{max-width:640px;margin:0 auto 28px;color:#444;}
 .hero{
-  background:linear-gradient(135deg,var(--green),var(--charcoal));
+  background:url('../img/logo.svg') center/cover no-repeat;
   color:#fff;
   padding:80px 20px;
 }
+.hero h1,.hero h2{color:#fff;}
 .hero .sub{color:#eee;}
 .btn{
   display:inline-block;padding:12px 26px;border-radius:8px;
@@ -78,4 +79,4 @@ h3{
 @media(max-width:600px){
   .three,.pricing .tiers{flex-direction:column;}
 }
-@media (prefers-color-scheme: dark){body{background:#121212;color:#eee;} .hero{color:#fff;background:linear-gradient(135deg,var(--green),#000);} .three .card,.tier,.testimonials blockquote{background:#1e1e1e;border-color:#333;color:#eee;} }
+@media (prefers-color-scheme: dark){body{background:#121212;color:#eee;} .hero{color:#fff;background:url('../img/logo.svg') center/cover no-repeat;} .three .card,.tier,.testimonials blockquote{background:#1e1e1e;border-color:#333;color:#eee;} }


### PR DESCRIPTION
## Summary
- change Jekyll remote theme to `jitinnair1/gradfolio`
- load the remote theme plugin
- clean up page front‑matter
- style hero section with logo background

## Testing
- `bundle install`
- `bundle exec jekyll build` *(fails: undefined method `configure_sass`)*

------
https://chatgpt.com/codex/tasks/task_e_6869449e98308323bd1a401e1e9bc63e