### PR TITLE
Update jekyll-remote-theme

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,5 @@ group :jekyll_plugins do
   gem "jekyll-include-cache"
   gem "jekyll-seo-tag"
   gem "jekyll-paginate"
-  gem "jekyll-remote-theme"
+  gem "jekyll-remote-theme", "~> 0.4.3"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,12 +78,13 @@ GEM
     jekyll-include-cache (0.2.1)
       jekyll (>= 3.7, < 5.0)
     jekyll-paginate (1.1.0)
-    jekyll-remote-theme (0.4.1)
+    jekyll-remote-theme (0.4.3)
       addressable (~> 2.0)
       jekyll (>= 3.5, < 5.0)
-      rubyzip (>= 1.3.0)
-    jekyll-sass-converter (3.1.0)
-      sass-embedded (~> 1.75)
+      jekyll-sass-converter (>= 1.0, <= 3.0.0, != 2.0.0)
+      rubyzip (>= 1.3.0, < 3.0)
+    jekyll-sass-converter (3.0.0)
+      sass-embedded (~> 1.54)
     jekyll-seo-tag (2.8.0)
       jekyll (>= 3.8, < 5.0)
     jekyll-sitemap (1.4.0)
@@ -174,7 +175,7 @@ DEPENDENCIES
   jekyll-archives
   jekyll-include-cache
   jekyll-paginate
-  jekyll-remote-theme
+  jekyll-remote-theme (~> 0.4.3)
   jekyll-seo-tag
   jekyll-sitemap
 


### PR DESCRIPTION
## Summary
- pin `jekyll-remote-theme` gem to version `0.4.3`
- update lockfile

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68694e505d2c832392d523f655a003a8